### PR TITLE
Force cassandra directories keys to be list

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,7 +70,7 @@
 
 - name: Custom Directories
   include: directory.yml
-  with_items: "{{ cassandra_directories.keys() }}"
+  with_items: "{{ cassandra_directories.keys() | list }}"
   loop_control:
     loop_var: cassandra_directory_set
   when:


### PR DESCRIPTION
Getting the following error when creating directory without this fix.

```
TASK [cassandra : Create Custom Directory] ***************************************************************************************************************************************************************************************************
fatal: [XX.XXX.XX.XX]: FAILED! => {"msg": "'dict object' has no attribute \"dict_keys(['root', 'data'])\""}
```