### PR TITLE
Test Against Fedora 27 and Python 3

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,6 +5,21 @@ driver:
   use_sudo: false
 
 platforms:
+  - name: fedora-28
+    driver_config:
+      image: fedora:28
+      run_command: /usr/sbin/init
+      privileged: true
+      provision_command:
+        - dnf install -y python3-pip rsyslog
+        - pip3 install ansible==2.6.0.0
+        - sed -i 's/#UseDNS yes/UseDNS no/g' /etc/ssh/sshd_config
+        - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
+        - sed -i 's/GSSAPIAuthentication yes/GSSAPIAuthentication no/g' /etc/ssh/sshd_config
+        - sed -i 's/#LogLevel INFO/LogLevel DEBUG/g' /etc/ssh/sshd_config
+        - systemctl enable rsyslog.service
+        - systemctl enable sshd.service
+
   - name: centos-7
     driver_config:
       run_command: /usr/sbin/init
@@ -54,6 +69,17 @@ verifier:
   sudo_path: true
 
 suites:
+  - name: Fedora
+    verifier:
+      patterns:
+        - tests/spec/common/*_spec.rb
+        - tests/spec/redhat/*_spec.rb
+    provisioner:
+      idempotency_test: true
+      playbook: tests/test.yml
+    includes:
+      - fedora-28
+
   - name: Redhat
     verifier:
       patterns:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,21 +5,6 @@ driver:
   use_sudo: false
 
 platforms:
-  - name: fedora-28
-    driver_config:
-      image: fedora:28
-      run_command: /usr/sbin/init
-      privileged: true
-      provision_command:
-        - dnf install -y python3-pip rsyslog
-        - pip3 install ansible==2.6.0.0
-        - sed -i 's/#UseDNS yes/UseDNS no/g' /etc/ssh/sshd_config
-        - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
-        - sed -i 's/GSSAPIAuthentication yes/GSSAPIAuthentication no/g' /etc/ssh/sshd_config
-        - sed -i 's/#LogLevel INFO/LogLevel DEBUG/g' /etc/ssh/sshd_config
-        - systemctl enable rsyslog.service
-        - systemctl enable sshd.service
-
   - name: centos-7
     driver_config:
       run_command: /usr/sbin/init
@@ -42,6 +27,21 @@ platforms:
       provision_command:
         - apt-get install -y apt-utils libffi-dev python-pycparser python-apt python-dev python-pip
         - pip install ansible==2.6.0.0
+
+  - name: fedora-28
+    driver_config:
+      image: fedora:28
+      run_command: /usr/sbin/init
+      privileged: true
+      provision_command:
+        - dnf install -y python3-pip rsyslog iproute yum-utils
+        - pip3 install ansible==2.6.0.0
+        - sed -i 's/#UseDNS yes/UseDNS no/g' /etc/ssh/sshd_config
+        - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
+        - sed -i 's/GSSAPIAuthentication yes/GSSAPIAuthentication no/g' /etc/ssh/sshd_config
+        - sed -i 's/#LogLevel INFO/LogLevel DEBUG/g' /etc/ssh/sshd_config
+        - systemctl enable rsyslog.service
+        - systemctl enable sshd.service
 
   - name: ubuntu-16.04
     driver_config:
@@ -69,18 +69,7 @@ verifier:
   sudo_path: true
 
 suites:
-  - name: Fedora
-    verifier:
-      patterns:
-        - tests/spec/common/*_spec.rb
-        - tests/spec/redhat/*_spec.rb
-    provisioner:
-      idempotency_test: true
-      playbook: tests/test.yml
-    includes:
-      - fedora-28
-
-  - name: Redhat
+  - name: ApplyRedhat
     verifier:
       patterns:
         - tests/spec/common/*_spec.rb
@@ -91,12 +80,18 @@ suites:
     includes:
       - centos-7
 
-  - name: Check
+  - name: ApplyFedora
+    verifier:
+      patterns:
+        - tests/spec/common/*_spec.rb
+        - tests/spec/redhat/*_spec.rb
     provisioner:
-      ansible_check: true
+      idempotency_test: true
       playbook: tests/test.yml
+    includes:
+      - fedora-28
 
-  - name: Debian
+  - name: ApplyDebian
     verifier:
       patterns:
         - tests/spec/common/*_spec.rb
@@ -107,3 +102,19 @@ suites:
     includes:
       - debian-9
       - ubuntu-16.04
+
+  - name: CheckNonFedora
+    provisioner:
+      ansible_check: true
+      playbook: tests/test.yml
+    excludes:
+      - fedora-28
+
+  - name: CheckFedora
+    provisioner:
+      ansible_check: true
+      extra_vars:
+        ansible_python_interpreter: /usr/bin/python3
+      playbook: tests/test.yml
+    includes:
+      - fedora-28

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -28,12 +28,13 @@ platforms:
         - apt-get install -y apt-utils libffi-dev python-pycparser python-apt python-dev python-pip
         - pip install ansible==2.6.0.0
 
-  - name: fedora-28
+  - name: fedora-27
     driver_config:
-      image: fedora:28
+      image: fedora:27
       run_command: /usr/sbin/init
       privileged: true
       provision_command:
+        - mkdir -p /var/run/cassandra
         - dnf install -y python3-pip rsyslog iproute yum-utils initscripts
         - pip3 install ansible==2.6.0.0
         - sed -i 's/#UseDNS yes/UseDNS no/g' /etc/ssh/sshd_config
@@ -54,7 +55,7 @@ provisioner:
   additional_copy_path:
     - tests
   ansible_inventory: tests/inventory
-  ansible_verbose: true
+  ansible_verbose: false
   ansible_verbosity: 1
   hosts: all
   name: ansible_playbook
@@ -89,7 +90,7 @@ suites:
       idempotency_test: true
       playbook: tests/test.yml
     includes:
-      - fedora-28
+      - fedora-27
 
   - name: ApplyDebian
     verifier:
@@ -108,7 +109,7 @@ suites:
       ansible_check: true
       playbook: tests/test.yml
     excludes:
-      - fedora-28
+      - fedora-27
 
   - name: CheckFedora
     provisioner:
@@ -117,4 +118,4 @@ suites:
         ansible_python_interpreter: /usr/bin/python3
       playbook: tests/test.yml
     includes:
-      - fedora-28
+      - fedora-27

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -34,7 +34,7 @@ platforms:
       run_command: /usr/sbin/init
       privileged: true
       provision_command:
-        - dnf install -y python3-pip rsyslog iproute yum-utils
+        - dnf install -y python3-pip rsyslog iproute yum-utils initscripts
         - pip3 install ansible==2.6.0.0
         - sed -i 's/#UseDNS yes/UseDNS no/g' /etc/ssh/sshd_config
         - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,6 @@ matrix:
   - python: 2.7
     env: INSTANCE="CheckNonFedora-ubuntu-1604"
   - python: 3.6
-    env: INSTANCE="ApplyFedora-fedora-28"
+    env: INSTANCE="ApplyFedora-fedora-27"
   - python: 3.6
-    env: INSTANCE="CheckFedora-fedora-28"
+    env: INSTANCE="CheckFedora-fedora-27"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,18 +39,18 @@ matrix:
   fast_finish: true
   include:
   - python: 2.7
-    env: INSTANCE="Redhat-centos"
+    env: INSTANCE="ApplyRedhat-centos-7"
   - python: 2.7
-    env: INSTANCE="Check-centos"
+    env: INSTANCE="ApplyFedora-fedora-28"
   - python: 2.7
-    env: INSTANCE="Check-ubuntu-1604"
+    env: INSTANCE="ApplyDebian-debian-9"
   - python: 2.7
-    env: INSTANCE="Debian-ubuntu-1604"
+    env: INSTANCE="ApplyDebian-ubuntu-1604"
   - python: 2.7
-    env: INSTANCE="Debian-debian-9"
+    env: INSTANCE="CheckNonFedora-centos-7"
   - python: 2.7
-    env: INSTANCE="Check-debian-9"
+    env: INSTANCE="CheckNonFedora-debian-9"
   - python: 2.7
-    env: INSTANCE="Fedora-fedora-28"
+    env: INSTANCE="CheckNonFedora-ubuntu-1604"
   - python: 2.7
-    env: INSTANCE="Check-fedora-28"
+    env: INSTANCE="CheckFedora-fedora-28"

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,7 @@ matrix:
     env: INSTANCE="Debian-debian-9"
   - python: 2.7
     env: INSTANCE="Check-debian-9"
+  - python: 2.7
+    env: INSTANCE="Fedora-fedora-28"
+  - python: 2.7
+    env: INSTANCE="Check-fedora-28"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - make lint
   - bundle exec kitchen list
   - bundle exec kitchen create $INSTANCE || true # A minor schlonk to avoid failure during kitchen build.
-  - bundle exec kitchen verify $INSTANCE
+  - bundle exec kitchen test $INSTANCE
   - make install_current_version
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - make lint
   - bundle exec kitchen list
   - bundle exec kitchen create $INSTANCE || true # A minor schlonk to avoid failure during kitchen build.
-  - bundle exec kitchen test $INSTANCE
+  - bundle exec kitchen verify $INSTANCE
   - make install_current_version
 
 notifications:
@@ -41,8 +41,6 @@ matrix:
   - python: 2.7
     env: INSTANCE="ApplyRedhat-centos-7"
   - python: 2.7
-    env: INSTANCE="ApplyFedora-fedora-28"
-  - python: 2.7
     env: INSTANCE="ApplyDebian-debian-9"
   - python: 2.7
     env: INSTANCE="ApplyDebian-ubuntu-1604"
@@ -52,5 +50,7 @@ matrix:
     env: INSTANCE="CheckNonFedora-debian-9"
   - python: 2.7
     env: INSTANCE="CheckNonFedora-ubuntu-1604"
-  - python: 2.7
+  - python: 3.6
+    env: INSTANCE="ApplyFedora-fedora-28"
+  - python: 3.6
     env: INSTANCE="CheckFedora-fedora-28"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
     - cassandra
     - centos
     - debian
+    - fedora
     - nosql
     - redhat
     - ubuntu
@@ -28,3 +29,6 @@ galaxy_info:
     - name: Debian
       versions:
         - stretch
+    - name: Fedora
+      versions:
+        - 28

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -31,4 +31,4 @@ galaxy_info:
         - stretch
     - name: Fedora
       versions:
-        - 28
+        - 27

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,9 +51,15 @@
     - ansible_processor_vcpus is defined
 
 - name: Install the Cassandra Package (YUM)
+  # Retries are in this as the cache has been seen to still be updating when
+  # this task gets to be executed.
   yum:
     name: "{{ cassandra_package }}"
     update_cache: yes
+  retries: 3
+  delay: 5
+  register: cassandra_yum_install_result
+  until: cassandra_yum_install_result is succeeded
   when:
     - ansible_os_family is defined
     - ansible_os_family == 'RedHat'


### PR DESCRIPTION
Wanted to initially build against Fedora 28 (latest stable) but seems it has a patch for systemd that doesn't play nicely with Cassandra (or rather _vice versa_) yet.

Fixes #23 .