### PR TITLE
Feature/centos rpm install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .kitchen/
+.python-version
 *.pyc
 *.rake_tasks~
 *.swp

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,8 +10,9 @@ platforms:
       platform: centos
       provision_command:
         - yum install -y epel-release
-        - yum install -y gcc python2-pip rsyslog initscripts python2-devel
-        - pip install ansible==2.6.0.0
+        - yum-config-manager --add-repo https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64 ansible
+        - rpm --import https://releases.ansible.com/keys/RPM-GPG-KEY-ansible-release.pub
+        - yum install -y ansible-2.6.0 initscripts rsyslog
         - sed -i 's/#UseDNS yes/UseDNS no/g' /etc/ssh/sshd_config
         - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
         - sed -i 's/GSSAPIAuthentication yes/GSSAPIAuthentication no/g' /etc/ssh/sshd_config

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -34,8 +34,10 @@ platforms:
       privileged: true
       provision_command:
         - mkdir -p /var/run/cassandra
-        - dnf install -y python3-pip rsyslog iproute yum-utils initscripts
-        - pip3 install ansible==2.6.0.0
+        - dnf install -y rsyslog iproute yum-utils initscripts
+        - yum-config-manager --add-repo https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64 ansible
+        - rpm --import https://releases.ansible.com/keys/RPM-GPG-KEY-ansible-release.pub
+        - dnf install -y ansible-2.6.0
         - sed -i 's/#UseDNS yes/UseDNS no/g' /etc/ssh/sshd_config
         - sed -i 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config
         - sed -i 's/GSSAPIAuthentication yes/GSSAPIAuthentication no/g' /etc/ssh/sshd_config


### PR DESCRIPTION
Install the CentOS/Fedora Ansible packages rather than using pip.  This is a bit quicker than pip, but is only available to the RPMs.  Unfortunately the back catalogue is not available for all versions of Debian/Ubuntu.