### PR TITLE
added tasks to configure log level and env

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,10 @@ cassandra_systemd_path: "/etc/systemd/system/cassandra.service"
 cassandra_systemd_template: "systemd/system/{{ ansible_facts.distribution }}/{{ ansible_facts.distribution_major_version }}/cassandra.service.j2"
 cassandra_task_delay: 10
 cassandra_task_retries: 5
+cassandra_log_config_file: /etc/cassandra/logback.xml
+cassandra_log_level: INFO
+cassandra_env_file: /etc/cassandra/cassandra-env.sh
+cassandra_log_path: /wsp_var/log/cassandra
+cassandra_env_configuration:
+  - name: CASSANDRA_LOG_DIR
+    value:  "{{ cassandra_log_path }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -157,6 +157,24 @@
   notify:
     - cassandra_restart_service
 
+- name: Configure cassandra settings.
+  lineinfile:
+    dest: "{{ cassandra_env_file }}"
+    regexp: "^#?{{ item.name }}.+$"
+    line: "{{ item.name }}='{{ item.value }}'"
+    state: "{{ item.state | default('present') }}"
+  with_items: "{{ cassandra_env_configuration }}"
+  notify:
+    - cassandra_restart_service
+
+- name: set cassandra log level
+  lineinfile:
+    dest: "{{ cassandra_log_config_file }}"
+    regexp: ^\s+<logger\sname="org.apache.cassandra"\slevel=".*"/>\s+$
+    line: <logger name="org.apache.cassandra" level="{{ cassandra_log_level }}"/>
+  notify:
+    - cassandra_restart_service
+
 - name: Set the DC for Cassandra
   lineinfile:
     dest: "{{ cassandra_configuration_file | dirname }}/cassandra-rackdc.properties"


### PR DESCRIPTION
log level config is a nice thing to have.
plus in the env you can configure heap and such (at least in ubuntu this feels right).
```
cassandra_env_configuration:
  - name: CASSANDRA_LOG_DIR
    value:  "{{ cassandra_log_path }}"
  - name: MAX_HEAP_SIZE
    value: 256M
  - name: HEAP_NEWSIZE
    value: 100M
```