### PR TITLE
Add the cassandra_regex_replacements variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ executes this module.
 * `cassandra_configuration` (default: *none*):
   The configuration for Cassandra.  See the example play book below.
 
+* `cassandra_configuration_directory` (default:
+  `/etc/cassandra/default.conf` on RedHat and
+  `/etc/cassandra` in Debian):
+  The directory of the Cassandra configuration.
+
 * `cassandra_configuration_file` (default:
   `/etc/cassandra/default.conf/cassandra.yaml` on RedHat and
   `/etc/cassandra/cassandra.yaml` on Debian):
@@ -52,6 +57,12 @@ executes this module.
   Whether to configure the Apache Cassandra repository.
 
   **SEE ALSO:** `cassandra_repo_apache_release`.
+
+* `cassandra_dc`:
+  If defined will set the Datacenter in `cassandra-rackdc.properties`.
+
+  This option is deprecated and will be removed in a future release.  Please
+  use `cassandra_regex_replacements` instead.
 
 * `cassandra_directories`:
   If defined, this will create directories after the package has been
@@ -79,6 +90,18 @@ executes this module.
 
 * `cassandra_package` (default: `cassandra`):
   The name of the package to be installed to provide Cassandra.
+
+* `cassandra_rack`:
+  If defined will set the rack in `cassandra-rackdc.properties`.
+
+  This option is deprecated and will be removed in a future release.  Please
+  use `cassandra_regex_replacements` instead.
+
+* `cassandra_regex_replacements` (default: []):
+  A list of hashes describing a `path` which is relative to
+  `cassandra_configuration_directory`, `regexp` which is a regular
+  expression to find in a file and `line` is the replacement within the
+  file.  See the example playbook for more details.
 
 * `cassandra_repo_apache_release` (default: *None*):
   The name of the release series (can be one of 311x, 30x, 22x, or 21x).  This
@@ -155,7 +178,6 @@ configuration:
             - seeds: "{{ ansible_default_ipv4.address }}"
       start_native_transport: true
     cassandra_configure_apache_repo: true
-    cassandra_dc: DC1
     # Create an alternative directories structure for the Cassandra data.
     # In this example, the will be a directory called /data owned by root
     # with rwxr-xr-x permissions.  It will have a series of sub-directories
@@ -175,21 +197,20 @@ configuration:
           - /data/cassandra/data
           - /data/cassandra/hints
           - /data/cassandra/saved_caches
-    cassandra_rack: RACK1
+    cassandra_regex_replacements:
+      - path: cassandra-env.sh
+        line: 'MAX_HEAP_SIZE="512M"'
+        regexp: '^#MAX_HEAP_SIZE="4G"'
+      - path: cassandra-env.sh
+        line: 'HEAP_NEWSIZE="100M"'
+        regexp: '^#HEAP_NEWSIZE="800M"'
+      - path: cassandra-rackdc.properties
+        line: 'dc=DC1'
+        regexp: '^dc='
+      - path: cassandra-rackdc.properties
+        line: 'rack=RACK1'
+        regexp: '^rack='
     cassandra_repo_apache_release: 311x
-
-  pre_tasks:
-    - name: Enable Systemd
-      set_fact:
-        cassandra_systemd_enabled: True
-      when: ansible_os_family == 'RedHat'
-
-    - name: Disable Cassandra Restart
-      set_fact:
-        cassandra_service_restart: False
-      when:
-        - ansible_os_family == 'Debian'
-        - ansible_distribution_major_version == '10'
 
   roles:
     - role: locp.cassandra

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ cassandra_configure_apache_repo: False
 cassandra_install_packages: True
 cassandra_package: cassandra
 cassandra_service_enabled: yes
+cassandra_regex_replacements: []
 cassandra_service_restart: True
 cassandra_service_state: started
 cassandra_systemd_enabled: False

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -22,7 +22,10 @@ RUN apt-get install -y --fix-missing apt-transport-https apt-utils python-apt su
   || apt-get install -y --fix-missing apt-transport-https apt-utils python-apt sudo bash ca-certificates
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9
 RUN echo 'deb http://repos.azulsystems.com/debian stable main' > /etc/apt/sources.list.d/zulu.list
-RUN apt-get clean
+RUN apt-get clean \
+    && apt-get update \
+    && apt-get install -y --fix-missing zulu-8 \
+    || apt-get install -y --fix-missing zulu-8
 {% elif item.image == 'fedora:30' or item.image == 'fedora:31' %}
 RUN dnf makecache \
   && dnf --assumeyes install python sudo python-devel python*-dnf bash \

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -25,7 +25,6 @@
             - seeds: "{{ ansible_default_ipv4.address }}"
       start_native_transport: true
     cassandra_configure_apache_repo: true
-    cassandra_dc: DC1
     # Create an alternative directories structure for the Cassandra data.
     # In this example, the will be a directory called /data owned by root
     # with rwxr-xr-x permissions.  It will have a series of sub-directories
@@ -45,7 +44,19 @@
           - /data/cassandra/data
           - /data/cassandra/hints
           - /data/cassandra/saved_caches
-    cassandra_rack: RACK1
+    cassandra_regex_replacements:
+      - path: cassandra-env.sh
+        line: 'MAX_HEAP_SIZE="512M"'
+        regexp: '^#MAX_HEAP_SIZE="4G"'
+      - path: cassandra-env.sh
+        line: 'HEAP_NEWSIZE="100M"'
+        regexp: '^#HEAP_NEWSIZE="800M"'
+      - path: cassandra-rackdc.properties
+        line: 'dc=DC1'
+        regexp: '^dc='
+      - path: cassandra-rackdc.properties
+        line: 'rack=RACK1'
+        regexp: '^rack='
     cassandra_repo_apache_release: 311x
 
   roles:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,7 +6,7 @@ driver:
   name: docker
 
 lint: |
-  set -e
+  set -ex
   yamllint -s .
   ansible-lint
   flake8

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -23,6 +23,7 @@
         - lsb-release
         - procps
         - python-apt
+        - zulu-8
       Fedora30:
         - initscripts
         - iproute
@@ -57,35 +58,13 @@
       debug:
         var: instance_info
 
-    - name: Install EPEL for CentOS 7
-      package:
-        name: epel-release
-      register: pkgstatus
-      until: pkgstatus is succeeded
-      when:
-        - ansible_distribution == 'CentOS'
-        - ansible_distribution_major_version == '7'
-
-    - name: Install RedHat Packages
-      package:
-        name: "{{ packages[instance_key] }}"
-      register: pkgstatus
-      until: pkgstatus is succeeded
-      when: ansible_os_family == 'RedHat'
-
-    - name: Install Debian Packages
-      apt:
-        name: "{{ packages[instance_key] }}"
-        update_cache: yes
-      register: pkgstatus
-      until: pkgstatus is succeeded
-      when: ansible_os_family == 'Debian'
-
     - name: Debian 10 Add Azul Key
       apt_key:
         keyserver: hkp://keyserver.ubuntu.com:80
         id: B1998361219BD9C9
+      delay: 10
       register: cassandra_remote_status
+      retries: 5
       until: cassandra_remote_status is succeeded
       when:
         - ansible_os_family == 'Debian'
@@ -100,12 +79,32 @@
         - ansible_os_family == 'Debian'
         - ansible_distribution_major_version == '10'
 
-    - name: Debian 10 Install Zulu Java
-      apt:
-        name: "zulu-8"
-        update_cache: yes
+    - name: Install EPEL for CentOS 7
+      package:
+        name: epel-release
+      delay: 10
       register: pkgstatus
+      retries: 5
       until: pkgstatus is succeeded
       when:
-        - ansible_os_family == 'Debian'
-        - ansible_distribution_major_version == '10'
+        - ansible_distribution == 'CentOS'
+        - ansible_distribution_major_version == '7'
+
+    - name: Install RedHat Packages
+      package:
+        name: "{{ packages[instance_key] }}"
+      delay: 10
+      register: pkgstatus
+      retries: 5
+      until: pkgstatus is succeeded
+      when: ansible_os_family == 'RedHat'
+
+    - name: Install Debian Packages
+      apt:
+        name: "{{ packages[instance_key] }}"
+        update_cache: yes
+      delay: 10
+      register: pkgstatus
+      retries: 5
+      until: pkgstatus is succeeded
+      when: ansible_os_family == 'Debian'

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -22,6 +22,14 @@ def get_config_path(host):
     return '/etc/cassandra'
 
 
+def test_heap_new_size(host):
+    """Test that the Cassandra cluster name has been set correctly."""
+    f = host.file('%s/cassandra-env.sh' % get_config_path(host))
+    assert f.exists
+    assert f.is_file
+    assert f.contains('MAX_HEAP_SIZE="512M"')
+
+
 def test_nodetool_status(host):
     """Test that 'nodetool status' contains UN for the node.
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -133,6 +133,7 @@
 
 - name: Set Default Configuration File Location (Debian)
   set_fact:
+    cassandra_configuration_directory: /etc/cassandra
     cassandra_configuration_file: /etc/cassandra/cassandra.yaml
   when:
     - ansible_os_family is defined
@@ -141,6 +142,7 @@
 
 - name: Set Default Configuration File Location (RedHat)
   set_fact:
+    cassandra_configuration_directory: /etc/cassandra/default.conf
     cassandra_configuration_file: /etc/cassandra/default.conf/cassandra.yaml
   when:
     - ansible_os_family is defined
@@ -154,6 +156,17 @@
     owner: root
     group: root
     mode: 0644
+  notify:
+    - cassandra_restart_service
+
+- name: Apply Regular Expression Updates to the Configuration
+  lineinfile:
+    line: "{{ item.line }}"
+    path: "{{ cassandra_configuration_directory }}/{{ item.path }}"
+    regexp: "{{ item.regexp }}"
+  loop: "{{ cassandra_regex_replacements }}"
+  when:
+    - not ansible_check_mode
   notify:
     - cassandra_restart_service
 


### PR DESCRIPTION
Adds a new variable called `cassandra_regex_replacements`.  This effectively deprecates the following variables:

- `cassandra_dc`
- `cassandra_rack`