### PR TITLE
Add New Variables For Memory Usage and CPU Utilisation v1.6.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
 ---
+AllCops:
+  NewCops: enable
+
 require:
   - rubocop-performance
   - rubocop-rails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.6.0](https://github.com/locp/ansible-role-cassandra/tree/1.6.0) (2020-08-05)
+
+[Full Changelog](https://github.com/locp/ansible-role-cassandra/compare/1.5.1...1.6.0)
+
+**Implemented enhancements:**
+
+- Add New Variables For Memory Usage and CPU Utilisation [\#91](https://github.com/locp/ansible-role-cassandra/issues/91)
+
 ## [1.5.1](https://github.com/locp/ansible-role-cassandra/tree/1.5.1) (2020-08-04)
 
 [Full Changelog](https://github.com/locp/ansible-role-cassandra/compare/1.5.0...1.5.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 [Full Changelog](https://github.com/locp/ansible-role-cassandra/compare/1.5.0...1.5.1)
 
+Many thanks to @aijanai for raising #93 and for his suggestions to improve the documentation to resolve the issue.
+
+
 **Implemented enhancements:**
 
 - Reintroduce Regular Builds Against Latest Versions [\#87](https://github.com/locp/ansible-role-cassandra/issues/87)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,11 @@ The general process for working on ansible-role-cassandra is:
 
 - Fork the project on Github
 - Clone your fork to your local machine
-- Create a feature branch from `develop` (e.g.
+- Create a feature branch from `master` (e.g.
   `git branch delete_all_the_code`)
 - Write code, commit often
 - Write test cases for all changed functionality
-- Submit a pull request against `develop` on Github
+- Submit a pull request against `master` on Github
 - Wait for code review!
 
 Things that will make your branch more likely to be pulled:

--- a/Gemfile
+++ b/Gemfile
@@ -4,16 +4,16 @@ source 'https://rubygems.org'
 
 group :development do
   gem 'github_changelog_generator',
-      '1.15.0'
+      '1.15.2'
 end
 
 group :test do
   gem 'rubocop',
-      '0.82.0'
+      '0.88.0'
   gem 'rubocop-performance',
-      '1.5.2'
+      '1.7.1'
   gem 'rubocop-rails',
-      '2.5.2'
+      '2.7.1'
   gem 'travis',
       '1.9.1'
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ansible-role-cassandra
 
-[![Build Status](https://travis-ci.com/locp/ansible-role-cassandra.svg?branch=develop)](https://travis-ci.com/locp/ansible-role-cassandra)
+[![Build Status](https://travis-ci.com/locp/ansible-role-cassandra.svg?branch=master)](https://travis-ci.com/locp/ansible-role-cassandra)
 [![Gitter](https://badges.gitter.im/ansible-role-cassandra/community.svg)](https://gitter.im/ansible-role-cassandra/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Ansible role to install and configure
@@ -34,14 +34,14 @@ executes this module.
   A custom fact that returns a value (MB) that might be suitable to set the
   HEAP_NEWSIZE when using the Concurrent Mark Sweep (CMS) Collector.  See
   [Tuning Java resources](https://docs.datastax.com/en/cassandra/2.1/cassandra/operations/ops_tune_jvm_c.html)
-  for more details.  Requires the `ansible_memtotal_mb` and
-  `ansible_processor_vcpus` facts to be set.
+  for more details.  Requires the `cassandra_memtotal_mb` and
+  `cassandra_processor_vcpus` facts to be set.
 
 * `cassandra_cms_max_heapsize_mb`:
   A custom fact that returns a value (MB) that might be suitable to set the
   MAX_HEAP_SIZE when using the Concurrent Mark Sweep (CMS) Collector.  See
   [Tuning Java resources](https://docs.datastax.com/en/cassandra/2.1/cassandra/operations/ops_tune_jvm_c.html)
-  for more details.  Requires the `ansible_memtotal_mb` fact to be set.
+  for more details.  Requires the `cassandra_memtotal_mb` fact to be set.
 
 * `cassandra_configuration` (default: *none*):
   The configuration for Cassandra.  See the example play book below.
@@ -79,8 +79,8 @@ executes this module.
   A custom fact that returns a value (MB) that might be suitable to set the
   HEAP_NEWSIZE.  See
   [Tuning Java resources](https://docs.datastax.com/en/cassandra/2.1/cassandra/operations/ops_tune_jvm_c.html)
-  for more details.  Requires the `ansible_memtotal_mb` and
-  `ansible_processor_vcpus` facts to be set.
+  for more details.  Requires the `cassandra_memtotal_mb` and
+  `cassandra_processor_vcpus` facts to be set.
 
 * `cassandra_install_packages` (default: **True**):
   A boolean value indicating if this Ansible role should attempt to install
@@ -102,7 +102,12 @@ executes this module.
   A custom fact that returns a value (MB) that might be suitable to set the
   MAX_HEAP_SIZE.  See
   [Tuning Java resources](https://docs.datastax.com/en/cassandra/2.1/cassandra/operations/ops_tune_jvm_c.html)
-  for more details.  Requires the `ansible_memtotal_mb` fact to be set.
+  for more details.  Requires the `cassandra_memtotal_mb` fact to be set.
+
+* `cassandra_memtotal_mb` (default: `ansible_memtotal_mb` if set):
+  Is used to calculate
+  `cassandra_cms_max_heapsize_mb`, `cassandra_max_heapsize_mb`,
+  `cassandra_cms_heap_new_size_mb` and `cassandra_heap_new_size_mb`.
 
 * `cassandra_node_count`:
   A read-only variable that attempts to contain the number of nodes in the
@@ -110,6 +115,10 @@ executes this module.
 
 * `cassandra_package` (default: `cassandra`):
   The name of the package to be installed to provide Cassandra.
+
+* `cassandra_processor_vcpus` (default: `ansible_processor_vcpus` if set):
+  Is used to calculate `cassandra_cms_heap_new_size_mb` and
+  `cassandra_heap_new_size_mb`.
 
 * `cassandra_rack`:
   If defined will set the rack in `cassandra-rackdc.properties`.
@@ -224,10 +233,10 @@ This playbook should be enough to configure Cassandra with a *very* basic
           - /data/cassandra/saved_caches
     cassandra_regex_replacements:
       - path: cassandra-env.sh
-        line: 'MAX_HEAP_SIZE="256M"'
+        line: 'MAX_HEAP_SIZE="{{ cassandra_max_heapsize_mb }}M"'
         regexp: '^#MAX_HEAP_SIZE="4G"'
       - path: cassandra-env.sh
-        line: 'HEAP_NEWSIZE="100M"'
+        line: 'HEAP_NEWSIZE="{{ cassandra_heap_new_size_mb }}M"'
         regexp: '^#HEAP_NEWSIZE="800M"'
       - path: cassandra-rackdc.properties
         line: 'dc=DC1'
@@ -249,7 +258,7 @@ and
 
 ## License
 
-[GPLv3](https://github.com/locp/ansible-role-cassandra/blob/develop/LICENSE)
+[GPLv3](https://github.com/locp/ansible-role-cassandra/blob/master/LICENSE)
 
 ## Author Information
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,5 +5,5 @@ require 'github_changelog_generator/task'
 GitHubChangelogGenerator::RakeTask.new :changelog do |config|
   config.user = 'locp'
   config.project = 'ansible-role-cassandra'
-  config.future_release = '1.5.1'
+  config.future_release = '1.6.0'
 end

--- a/molecule/combine_cluster/converge.yml
+++ b/molecule/combine_cluster/converge.yml
@@ -51,10 +51,10 @@
           - /data/cassandra/saved_caches
     cassandra_regex_replacements:
       - path: cassandra-env.sh
-        line: 'MAX_HEAP_SIZE="256M"'
+        line: 'MAX_HEAP_SIZE="{{ cassandra_max_heapsize_mb }}M"'
         regexp: '^#MAX_HEAP_SIZE="4G"'
       - path: cassandra-env.sh
-        line: 'HEAP_NEWSIZE="100M"'
+        line: 'HEAP_NEWSIZE="{{ cassandra_heap_new_size_mb }}M"'
         regexp: '^#HEAP_NEWSIZE="800M"'
       - path: cassandra-rackdc.properties
         line: 'dc=DC1'

--- a/molecule/combine_cluster/molecule.yml
+++ b/molecule/combine_cluster/molecule.yml
@@ -42,8 +42,10 @@ provisioner:
 
   inventory:
     group_vars:
-      all:
+      cassandra:
         cassandra_join_cluster: True
+        cassandra_memtotal_mb: 1280
+        cassandra_processor_vcpus: 1
       centos7:
         cassandra_systemd_enabled: True
       centos8:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -49,10 +49,10 @@
           - /data/cassandra/saved_caches
     cassandra_regex_replacements:
       - path: cassandra-env.sh
-        line: 'MAX_HEAP_SIZE="256M"'
+        line: 'MAX_HEAP_SIZE="{{ cassandra_max_heapsize_mb }}M"'
         regexp: '^#MAX_HEAP_SIZE="4G"'
       - path: cassandra-env.sh
-        line: 'HEAP_NEWSIZE="100M"'
+        line: 'HEAP_NEWSIZE="{{ cassandra_heap_new_size_mb }}M"'
         regexp: '^#HEAP_NEWSIZE="800M"'
       - path: cassandra-rackdc.properties
         line: 'dc=DC1'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -48,6 +48,9 @@ provisioner:
 
   inventory:
     group_vars:
+      cassandra:
+        cassandra_memtotal_mb: 1280
+        cassandra_processor_vcpus: 1
       centos7:
         cassandra_systemd_enabled: True
       centos8:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -27,7 +27,7 @@ def test_heap_new_size(host):
     f = host.file('%s/cassandra-env.sh' % get_config_path(host))
     assert f.exists
     assert f.is_file
-    assert f.contains('MAX_HEAP_SIZE="256M"')
+    assert f.contains('MAX_HEAP_SIZE="640M"')
 
 
 def test_nodetool_status(host):

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,50 +8,64 @@
   include: join_cluster.yml
   when: cassandra_join_cluster | bool
 
+- name: Set default value for cassandra_memtotal_mb
+  set_fact:
+    cassandra_memtotal_mb: "{{ ansible_memtotal_mb }}"
+  when:
+    - ansible_memtotal_mb is defined
+    - cassandra_memtotal_mb is not defined
+
+- name: Set default value for cassandra_processor_vcpus
+  set_fact:
+    cassandra_processor_vcpus: "{{ ansible_processor_vcpus }}"
+  when:
+    - ansible_processor_vcpus is defined
+    - cassandra_processor_vcpus is not defined
+
 - name: Calculate cassandra_cms_max_heapsize_mb
   set_fact:
     cassandra_cms_max_heapsize_mb: "{{
       [
-        ([ansible_memtotal_mb * 0.5, 1024] | min),
-        ([ansible_memtotal_mb * 0.25, 14336] | min)
+        ([cassandra_memtotal_mb * 0.5, 1024] | min),
+        ([cassandra_memtotal_mb * 0.25, 14336] | min)
       ] | max | round | int }}"
   when:
-    - ansible_memtotal_mb is defined
+    - cassandra_memtotal_mb is defined
     - cassandra_cms_max_heapsize_mb is not defined
 
 - name: Calculate cassandra_max_heapsize_mb
   set_fact:
     cassandra_max_heapsize_mb: "{{
       [
-        ([ansible_memtotal_mb * 0.5, 1024] | min),
-        ([ansible_memtotal_mb * 0.25, 8192] | min)
+        ([cassandra_memtotal_mb * 0.5, 1024] | min),
+        ([cassandra_memtotal_mb * 0.25, 8192] | min)
       ] | max | round | int }}"
   when:
-    - ansible_memtotal_mb is defined
+    - cassandra_memtotal_mb is defined
     - cassandra_max_heapsize_mb is not defined
 
 - name: Calculate cassandra_cms_heap_new_size_mb
   set_fact:
     cassandra_cms_heap_new_size_mb: "{{
       [
-        (ansible_processor_vcpus * 100.0),
+        (cassandra_processor_vcpus * 100.0),
         ((cassandra_cms_max_heapsize_mb | int) * 0.25)
       ] | min | round | int }}"
   when:
-    - ansible_memtotal_mb is defined
-    - ansible_processor_vcpus is defined
+    - cassandra_memtotal_mb is defined
+    - cassandra_processor_vcpus is defined
     - cassandra_cms_heap_new_size_mb is not defined
 
 - name: Calculate cassandra_heap_new_size_mb
   set_fact:
     cassandra_heap_new_size_mb: "{{
       [
-        (ansible_processor_vcpus * 100.0),
+        (cassandra_processor_vcpus * 100.0),
         ((cassandra_max_heapsize_mb | int) * 0.25)
       ] | min | round | int }}"
   when:
-    - ansible_memtotal_mb is defined
-    - ansible_processor_vcpus is defined
+    - cassandra_memtotal_mb is defined
+    - cassandra_processor_vcpus is defined
     - cassandra_heap_new_size_mb is not defined
 
 - name: Debug Custom Facts
@@ -62,7 +76,10 @@
       'cassandra_cms_heap_new_size_mb': "{{ cassandra_cms_heap_new_size_mb }}",
       'cassandra_cms_max_heapsize_mb': "{{ cassandra_cms_max_heapsize_mb }}",
       'cassandra_heap_new_size_mb': "{{ cassandra_heap_new_size_mb }}",
-      'cassandra_max_heapsize_mb': "{{ cassandra_max_heapsize_mb }}"
+      'cassandra_node_count': "{{ cassandra_node_count | default('N/A') }}",
+      'cassandra_max_heapsize_mb': "{{ cassandra_max_heapsize_mb }}",
+      'cassandra_memtotal_mb': "{{ cassandra_memtotal_mb }}",
+      'cassandra_processor_vcpus': "{{ cassandra_processor_vcpus }}"
     }
     verbosity: 1
   when:


### PR DESCRIPTION
This PR does the following:

- Fixes #91 (add the `cassandra_memtotal_mb` and `cassandra_processor_vcpus` variables).
- Migrates from GitFlow to GitHub flow.
