### PR TITLE
Rename reference to locp.cassandra to locp.ansible_role_cassandra.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python: 3.6
 
 # Install ansible
 install:
-  - ln -s $( basename $PWD ) ../locp.cassandra
+  - ln -s $( basename $PWD ) ../locp.ansible_role_cassandra
   - bundle install
   - pip install -Ur requirements.txt
   - pip freeze

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 [![Gitter](https://badges.gitter.im/ansible-role-cassandra/community.svg)](https://gitter.im/ansible-role-cassandra/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Ansible role to install and configure
-[Apache Cassandra](http://cassandra.apache.org/).
+[Apache Cassandra](http://cassandra.apache.org/).  After version 1.6.0 this
+role was [renamed](https://github.com/locp/ansible-role-cassandra/issues/98)
+from `locp.cassandra` to `locp.ansible_role_cassandra` in Ansible Galaxy.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ This playbook should be enough to configure Cassandra with a *very* basic
 
 ```YAML
 ---
-- name: Example Playbook for the locp.cassandra Role
+- name: Example Playbook for the locp.ansible_role_cassandra Role
 
   hosts: cassandra
 
@@ -247,7 +247,7 @@ This playbook should be enough to configure Cassandra with a *very* basic
     cassandra_repo_apache_release: 311x
 
   roles:
-    - role: locp.cassandra
+    - role: locp.ansible_role_cassandra
 ```
 
 To see the playbooks that are used for

--- a/molecule/combine_cluster/converge.yml
+++ b/molecule/combine_cluster/converge.yml
@@ -1,5 +1,5 @@
 ---
-- name: Example Playbook for the locp.cassandra Role
+- name: Example Playbook for the locp.ansible_role_cassandra Role
 
   hosts: cassandra
 
@@ -65,7 +65,7 @@
     cassandra_repo_apache_release: 311x
 
   roles:
-    - role: locp.cassandra
+    - role: locp.ansible_role_cassandra
 
   post_tasks:
     - name: Wait for the Cassandra Listener

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,5 +1,5 @@
 ---
-- name: Example Playbook for the locp.cassandra Role
+- name: Example Playbook for the locp.ansible_role_cassandra Role
 
   hosts: cassandra
 
@@ -77,7 +77,7 @@
       when: "'standalone' is in group_names"
 
   roles:
-    - role: locp.cassandra
+    - role: locp.ansible_role_cassandra
 
   post_tasks:
     - name: Wait for the Cassandra Listener

--- a/molecule/latest/converge.yml
+++ b/molecule/latest/converge.yml
@@ -1,5 +1,5 @@
 ---
-- name: Example Playbook for the locp.cassandra Role
+- name: Example Playbook for the locp.ansible_role_cassandra Role
 
   hosts: cassandra
 
@@ -74,7 +74,7 @@
       when: "'standalone' is in group_names"
 
   roles:
-    - role: locp.cassandra
+    - role: locp.ansible_role_cassandra
 
   post_tasks:
     - name: Wait for the Cassandra Listener


### PR DESCRIPTION
Fixes #98.