### PR TITLE
Hotfix 1.6.7

### DIFF
--- a/.github/workflows/fedora32.yml
+++ b/.github/workflows/fedora32.yml
@@ -1,5 +1,5 @@
 ---
-name: CI Fedora 33
+name: CI Fedora 32
 
 on:
   pull_request:
@@ -34,12 +34,12 @@ jobs:
       env:
         COMMAND: /usr/sbin/init
         DISTRO: fedora
-        TAG: 33
+        TAG: 32
       run: molecule test --destroy never
 
     - name: Combine the Clusters
       env:
         COMMAND: /usr/sbin/init
         DISTRO: fedora
-        TAG: 33
+        TAG: 32
       run: molecule test --scenario-name combine_cluster

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ executes this module.
   installed (therefore when the cassandra user is available) but before
   Cassandra is configured.  See the example playbook for more details.
 
+  Please note that when used with the `cassandra_join_cluster` option the
+  paths specified here will be deleted (with all their contents) and
+  recreated so that the node can join a cluster correctly.
+
 * `cassandra_heap_new_size_mb`:
   A custom fact that returns a value (MB) that might be suitable to set the
   HEAP_NEWSIZE.  See

--- a/tasks/join_cluster.yml
+++ b/tasks/join_cluster.yml
@@ -49,7 +49,7 @@
   file:
     state: absent
     path: "{{ item }}"
-  with_items: "{{ cassandra_directories.keys() | list }}"
+  with_items: "{{ cassandra_directories.data.paths }}"
   when:
     - cassandra_node_count is defined
     - cassandra_node_count == '1'


### PR DESCRIPTION
This PR fixes some of the issues (certainly not all) raised in #116.  What it does deliver (and is considered urgent enough for a hotfix) is:

- Correct the path names of the directories that are removed as part of the `cassandra_join_cluster` process.  Prior to this, what was deleted was incorrect, somewhat arbitrary and could have had disastrous effects on a system!
- Clarify in the documentation what happens to the data directories when using `cassandra_join_cluster`.