### PR TITLE
FIXED Add apache apt keys

### DIFF
--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -2,18 +2,11 @@
 
 - name: Add the Apache Apt Keys
   apt_key:
-    keyserver: pool.sks-keyservers.net
-    id: "{{ key }}"
+    url: https://downloads.apache.org/cassandra/KEYS
   register: cassandra_remote_status
   until: cassandra_remote_status is succeeded
   delay: "{{ cassandra_task_delay }}"
   retries: "{{ cassandra_task_retries }}"
-  loop:
-    - A278B781FE4B2BDA
-    - E91335D77E3E87CB
-    - F1000962B7F6840C
-  loop_control:
-    loop_var: key
   when:
     - cassandra_configure_apache_repo|bool
 


### PR DESCRIPTION
While deploying the role on my debian instance i got the following error message:
```
TASK [cassandra : Add the Apache Apt Keys] *************************************
FAILED - RETRYING: Add the Apache Apt Keys (5 retries left).
FAILED - RETRYING: Add the Apache Apt Keys (4 retries left).
FAILED - RETRYING: Add the Apache Apt Keys (3 retries left).
FAILED - RETRYING: Add the Apache Apt Keys (2 retries left).
FAILED - RETRYING: Add the Apache Apt Keys (1 retries left).
failed: [cassandra] (item=A278B781FE4B2BDA) => {"ansible_loop_var": "key", "attempts": 5, "changed": false, "cmd": "/usr/bin/apt-key adv --no-tty --keyserver pool.sks-keyservers.net --recv A278B781FE4B2BDA", "key": "A278B781FE4B2BDA", "msg": "Error fetching key A278B781FE4B2BDA from keyserver: pool.sks-keyservers.net", "rc": 2, "stderr": "Warning: apt-key output should not be parsed (stdout is not a terminal)\ngpg: keyserver receive failed: No name\n", "stderr_lines": ["Warning: apt-key output should not be parsed (stdout is not a terminal)", "gpg: keyserver receive failed: No name"], "stdout": "Executing: /tmp/apt-key-gpghome.BVDNSR6e8v/gpg.1.sh --no-tty --keyserver pool.sks-keyservers.net --recv A278B781FE4B2BDA\n", "stdout_lines": ["Executing: /tmp/apt-key-gpghome.BVDNSR6e8v/gpg.1.sh --no-tty --keyserver pool.sks-keyservers.net --recv A278B781FE4B2BDA"]}
```

After looking into the [installation documentation](https://cassandra.apache.org/doc/latest/getting_started/installing.html#installing-the-debian-packages) i saw that they changed the step with the gpg imports to `curl https://downloads.apache.org/cassandra/KEYS | sudo apt-key add -`

The change fixed the "gpg key" task and the repo add was successfull.