### PR TITLE
Fix for not defined cassandra_directories

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -7,7 +7,7 @@
     owner: "{{ directory.0.spec.owner | default('cassandra') }}"
     path: "{{ directory.1 }}"
     state: directory
-  loop: "{{ cassandra_directories
+  loop: "{{ cassandra_directories | default({})
             | dict2items(key_name='set', value_name='spec')
             | subelements('spec.paths') }}"
   loop_control:


### PR DESCRIPTION
When not defining 'cassandra_directories' got error:
FAILED! => {"msg": "dict2items requires a dictionary, got <class 'ansible.template.AnsibleUndefined'> instead."}