### PR TITLE
fix: Change apache package repository URLs to new location

### DIFF
--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -13,7 +13,7 @@
 - name: Configure the Apache Cassandra Apt Repository
   ansible.builtin.apt_repository:
     filename: /etc/apt/sources.list.d/cassandra.sources
-    repo: "deb http://www.apache.org/dist/cassandra/debian {{ cassandra_repo_apache_release }} main"
+    repo: "deb https://debian.cassandra.apache.org {{ cassandra_repo_apache_release }} main"
     state: present
   when:
     - cassandra_configure_apache_repo|bool

--- a/tasks/install/RedHat.yml
+++ b/tasks/install/RedHat.yml
@@ -3,7 +3,7 @@
 - name: Configure the Apache Cassandra YUM Repository
   ansible.builtin.yum_repository:
     name: cassandra
-    baseurl: "https://www.apache.org/dist/cassandra/redhat/{{ cassandra_repo_apache_release }}/"
+    baseurl: "https://redhat.cassandra.apache.org/{{ cassandra_repo_apache_release }}/"
     gpgcheck: true
     description: Apache Cassandra
     repo_gpgcheck: true


### PR DESCRIPTION
Hi there, 

I just stumbled upon this by coincidence yesterday. The cassandra packages are moving soon and are already available under the new URLs, see https://issues.apache.org/jira/browse/CASSANDRA-17748 for more context. 

Best,
Hauke 